### PR TITLE
Fix typo in export_metrics

### DIFF
--- a/lib/metrics/ogs-metrics.c
+++ b/lib/metrics/ogs-metrics.c
@@ -52,11 +52,11 @@ static char *export_metrics(char *resp, ogs_list_t *metrics)
             {
                 int cnt = 0;
                 ogs_metrics_label_t *label;
+                resp = ogs_mstrcatf(resp, "%s{",metric->name);
 
                 ogs_list_for_each(&label_list->labels, label)
                 {
-                    resp = ogs_mstrcatf(resp, "%s%s%s=\"%s\"",
-                        (cnt == 0) ? metric->name : "",
+                    resp = ogs_mstrcatf(resp, "%s%s=\"%s\"",
                         (cnt > 0) ? "," : "",
                         label->label_name, label->label_value);
 

--- a/src/amf/metrics.c
+++ b/src/amf/metrics.c
@@ -67,11 +67,17 @@ int metrics_open(void)
     ogs_metrics_gauge_set(sample1, 0);
 
     gauge_gnb_cnt = ogs_metrics_create(OGS_METRICS_TYPE_GAUGE,
-            "amf_gnb_cnt", "Count of gNB's connected", 0, NULL);
+        "amf_gnb_cnt", "Count of gNB's connected", 
+        1, (const char * [][2]){
+        {"amf_name", amf_self()->amf_name }
+        });
     ogs_assert(gauge_gnb_cnt);
 
     gauge_ran_ue_cnt = ogs_metrics_create(OGS_METRICS_TYPE_GAUGE,
-            "amf_ran_ue_cnt", "Count of RAN UE's", 0, NULL);
+            "amf_ran_ue_cnt", "Count of RAN UE's",
+        1, (const char * [][2]){
+        {"amf_name", amf_self()->amf_name }
+        });
     ogs_assert(gauge_ran_ue_cnt);
 
 


### PR DESCRIPTION
Current code text representation is:
```
# HELP gauge_name gauge help
# TYPE gauge_name gauge
gauge_name 10
gauge_namelabel="value"} 20
gauge_namelabel="value",label2="value2"} 2
# HELP amf_gnb_cnt Count of gNB's connected
# TYPE amf_gnb_cnt gauge
amf_gnb_cnt 0
# HELP amf_ran_ue_cnt Count of RAN UE's
# TYPE amf_ran_ue_cnt gauge
amf_ran_ue_cnt 0
```
This PR change the text representation to:
```
# HELP gauge_name gauge help
# TYPE gauge_name gauge
gauge_name 10
gauge_name{label="value"} 20
gauge_name{label="value",label2="value2"} 2
# HELP amf_gnb_cnt Count of gNB's connected
# TYPE amf_gnb_cnt gauge
amf_gnb_cnt 0
# HELP amf_ran_ue_cnt Count of RAN UE's
# TYPE amf_ran_ue_cnt gauge
amf_ran_ue_cnt 0
```